### PR TITLE
App 9900 stateful arm saver switch position

### DIFF
--- a/touch/arm_position_saver.go
+++ b/touch/arm_position_saver.go
@@ -80,10 +80,11 @@ func newArmPositionSaver(ctx context.Context, deps resource.Dependencies, config
 	logger.Infof("config: %#v", newConf)
 
 	aps := &ArmPositionSaver{
-		name:   config.ResourceName(),
-		cfg:    newConf,
-		logger: logger,
-		arm:    arm,
+		name:           config.ResourceName(),
+		switchPosition: 0,
+		cfg:            newConf,
+		logger:         logger,
+		arm:            arm,
 	}
 
 	if newConf.Motion != "" {
@@ -119,6 +120,7 @@ type ArmPositionSaver struct {
 	cfg    *ArmPositionSaverConfig
 	logger logging.Logger
 
+	switchPosition uint32
 	arm            arm.Arm
 	motion         motion.Service
 	visionServices []vision.Service
@@ -148,22 +150,31 @@ func (aps *ArmPositionSaver) DoCommand(ctx context.Context, cmd map[string]inter
 
 func (aps *ArmPositionSaver) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
 	if position == 0 {
+		aps.switchPosition = position
 		return nil
 	}
 
 	if position == 1 {
-		return aps.saveCurrentPosition(ctx)
+		aps.switchPosition = position
+		err := aps.saveCurrentPosition(ctx)
+		// go back to idle once done
+		// aps.switchPosition = 0
+		return err
 	}
 
 	if position == 2 {
-		return aps.goToSavePosition(ctx)
+		aps.switchPosition = position
+		err := aps.goToSavePosition(ctx)
+		// go back to idle once done
+		// aps.switchPosition = 0
+		return err
 	}
 
 	return fmt.Errorf("bad position: %d", position)
 }
 
 func (aps *ArmPositionSaver) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {
-	return 0, nil
+	return aps.switchPosition, nil
 }
 
 func (aps *ArmPositionSaver) GetNumberOfPositions(ctx context.Context, extra map[string]interface{}) (uint32, []string, error) {

--- a/touch/arm_position_saver.go
+++ b/touch/arm_position_saver.go
@@ -149,26 +149,25 @@ func (aps *ArmPositionSaver) DoCommand(ctx context.Context, cmd map[string]inter
 }
 
 func (aps *ArmPositionSaver) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
-	aps.switchPosition = position
-	if position == 0 {
+	switch position {
+	case 0:
+		aps.switchPosition = position
 		return nil
-	}
-
-	if position == 1 {
+	case 1:
+		aps.switchPosition = position
 		err := aps.saveCurrentPosition(ctx)
 		// go back to idle once done
 		aps.switchPosition = 0
 		return err
-	}
-
-	if position == 2 {
+	case 2:
+		aps.switchPosition = position
 		err := aps.goToSavePosition(ctx)
 		// go back to idle once done
 		aps.switchPosition = 0
 		return err
+	default:
+		return fmt.Errorf("bad position: %d", position)
 	}
-
-	return fmt.Errorf("bad position: %d", position)
 }
 
 func (aps *ArmPositionSaver) GetPosition(ctx context.Context, extra map[string]interface{}) (uint32, error) {

--- a/touch/arm_position_saver.go
+++ b/touch/arm_position_saver.go
@@ -149,13 +149,12 @@ func (aps *ArmPositionSaver) DoCommand(ctx context.Context, cmd map[string]inter
 }
 
 func (aps *ArmPositionSaver) SetPosition(ctx context.Context, position uint32, extra map[string]interface{}) error {
+	aps.switchPosition = position
 	if position == 0 {
-		aps.switchPosition = position
 		return nil
 	}
 
 	if position == 1 {
-		aps.switchPosition = position
 		err := aps.saveCurrentPosition(ctx)
 		// go back to idle once done
 		aps.switchPosition = 0
@@ -163,7 +162,6 @@ func (aps *ArmPositionSaver) SetPosition(ctx context.Context, position uint32, e
 	}
 
 	if position == 2 {
-		aps.switchPosition = position
 		err := aps.goToSavePosition(ctx)
 		// go back to idle once done
 		aps.switchPosition = 0

--- a/touch/arm_position_saver.go
+++ b/touch/arm_position_saver.go
@@ -158,7 +158,7 @@ func (aps *ArmPositionSaver) SetPosition(ctx context.Context, position uint32, e
 		aps.switchPosition = position
 		err := aps.saveCurrentPosition(ctx)
 		// go back to idle once done
-		// aps.switchPosition = 0
+		aps.switchPosition = 0
 		return err
 	}
 
@@ -166,7 +166,7 @@ func (aps *ArmPositionSaver) SetPosition(ctx context.Context, position uint32, e
 		aps.switchPosition = position
 		err := aps.goToSavePosition(ctx)
 		// go back to idle once done
-		// aps.switchPosition = 0
+		aps.switchPosition = 0
 		return err
 	}
 


### PR DESCRIPTION
# Description
In this ticket https://viam.atlassian.net/browse/APP-9900 we saw users complaining about reactivity of the switch when using the arm-position-saver switch component.

The first change is to optimistically update the ui: https://github.com/viamrobotics/app/pull/11263

This PR makes it so the switchPosition state is accurately stored and returned as part of the SetPosition and GetPosition lifecycle

# Testing
- deployed a local module version of vmodutils to local app robot and saw reactive switch updates properly take place.


https://github.com/user-attachments/assets/7b6947f5-f695-459c-98e7-610b469ca727

