### PR TITLE
Fix GetPathInCaptureDir double-appending .viam in module context

### DIFF
--- a/file_utils/file_utils.go
+++ b/file_utils/file_utils.go
@@ -17,6 +17,9 @@ import (
 )
 
 func GetPathInCaptureDir(subDirName string) string {
+	if viamHome := os.Getenv(rutils.HomeEnvVar); viamHome != "" {
+		return filepath.Join(viamHome, "capture", subDirName)
+	}
 	return filepath.Join(shared.ViamCaptureDotDir, subDirName)
 }
 


### PR DESCRIPTION
When running as a module, `local_robot.go` in rdk passes the `.viam` directory (`/home/viam/.viam`) as `VIAM_HOME` to modules

`GetPathInCaptureDir` was using `shared.ViamCaptureDotDir` which appends `.viam` to `VIAM_HOME` again, causing files to be written to `/home/viam/.viam/.viam/capture` instead of `/home/viam/.viam/capture`

The data manager monitors `/home/viam/.viam/capture`, so files were never synced to the cloud

Fix: when `VIAM_HOME` is set, use it directly as the capture directory root
Fall back to `shared.ViamCaptureDotDir` when `VIAM_HOME` is not set
