### PR TITLE
Revert capture dir fix - RDK fix removes the need for this workaround

### DIFF
--- a/file_utils/file_utils.go
+++ b/file_utils/file_utils.go
@@ -17,9 +17,6 @@ import (
 )
 
 func GetPathInCaptureDir(subDirName string) string {
-	if viamHome := os.Getenv(rutils.HomeEnvVar); viamHome != "" {
-		return filepath.Join(viamHome, "capture", subDirName)
-	}
 	return filepath.Join(shared.ViamCaptureDotDir, subDirName)
 }
 


### PR DESCRIPTION
Reverts the GetPathInCaptureDir change from jb/fix-capture-dir-path - didn't mean to go through with that change

The original fix worked around local_robot.go in RDK passing `VIAM_HOME` to modules with /.viam already appended, causing vmodutils to double-append it

**RDK is fixing this at the source - modules will receive `VIAM_HOME` as the raw home dir again so that they don't break modules setting VIAM_HOME more generally**   
