### PR TITLE
docs: rewrite README and link models to anchors in meta.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,141 +1,461 @@
-
+# vmodutils Module
 
 <p align="center">
   <a href="https://pkg.go.dev/github.com/erh/vmodutils"><img src="https://pkg.go.dev/badge/github.com/erh/vmodutils" alt="PkgGoDev"></a>
-</a>
 </p>
 
-## pc crop camera
-```
+The `erh:vmodutils` module bundles a few utility models for arm-based automation, point-cloud processing, and data-capture orchestration:
+
+1. **`erh:vmodutils:pc-crop-camera`** — A camera that crops a source point cloud to an axis-aligned world-frame box, with optional RGB color filtering.
+2. **`erh:vmodutils:pc-detect-crop-camera`** — A camera that crops a point cloud to the 2D bounding boxes returned by a vision service's detections.
+3. **`erh:vmodutils:pc-merge`** — A camera that fetches point clouds from a list of source cameras and merges them into one.
+4. **`erh:vmodutils:pc-look-at-crop-camera`** — A camera that isolates the cluster of points closest to the camera centerline (with optional center-color matching).
+5. **`erh:vmodutils:pc-multiple-arm-poses`** — A camera that drives a list of arm-position switches through their saved poses, captures a point cloud at each, and merges them in the world frame.
+6. **`erh:vmodutils:pc-cluster`** — A vision service that segments a camera's point cloud into spatial clusters and returns them as `ObjectPointClouds`.
+7. **`erh:vmodutils:arm-position-saver`** — A switch that records the current arm pose into module config and later moves the arm back to it.
+8. **`erh:vmodutils:multi-arm-position-switch`** — A switch that moves an arm between a configured list of joint positions, one per switch index.
+9. **`erh:vmodutils:obstacle`** — A gripper that doesn't grip — it just publishes a set of static `Geometries` so the motion service can avoid them.
+10. **`erh:vmodutils:obstacle-open-box`** — A gripper that publishes the five faces of an open-top box as obstacle geometries, and can drive an arm to the box opening.
+11. **`erh:vmodutils:calibration-checker`** — A sensor that compares world-frame positions of a shared AprilTag across two or more pose trackers to detect arm/camera drift.
+12. **`erh:vmodutils:session-capture`** — A sensor wired into the data manager's `capture_control_sensor` that toggles capture on/off for a list of components and tags clips with a session id.
+
+---
+
+## Model: `erh:vmodutils:pc-crop-camera`
+
+**API:** `rdk:component:camera`
+
+Wraps a source camera and crops its point cloud to an axis-aligned bounding box specified in the **world frame**. Optionally filters points by RGB color similarity.
+
+### Configuration
+
+```json
 {
-  "src" : "<cam>",
-  "src_frame" : <optional>, // src point cloud will be converted to world from this, if not specified assume it is world
-  "min" : { "X" : 0, "Y" : 0, "Z" : 0}, // specified in world frame
-  "min" : { "X" : 9, "Y" : 9, "Z" : 9}  // specified in world frame
-}
-  
-```
-
-## pc detect crop camera
-```
-{
-  "src" : "<cam>",
-  "service" : "<vision service>"
-}
-```
-
-## pc merge
-```
-{
-  "cameras" : ["<cam>"]
-}
-```
-
-## arm position saver
-```
-{
-    // required
-    "arm" : "<name of arm>",
-
-    // optional
-    // if motion and joints are set, uses joint to joint motion via motion.Move
-    // if motion and pose are set, uses cartesian motion via motion.Move
-    // if motion is not set and joints are set, uses arm.MoveToJointPositions
-    "motion" : "<name of motion service>",
-
-    // can be set automatically via SetPosition command
-    "joints" : [ ],
-    "point" : < ... >,
-    "orientation" : < ... >,
-
-    // optional - if set, the Geometry objects in the vision services' GetObjectPointClouds results
-    // are added to the world state passed to the motion service
-    "vision_services": ["<name of vision service>"],
-
-    // optional - options passed as 'extra' to motion.Move or arm.MoveToJointPositions
-    "extra" : "<options>",
-
-    // optional - motion constraints passed to motion.Move (only used when motion service is set)
-    "constraints" : < ... >
+  "src": "<string>",
+  "src_frame": "<string>",
+  "min": { "X": 0, "Y": 0, "Z": 0 },
+  "max": { "X": 100, "Y": 100, "Z": 100 },
+  "good_colors": [
+    { "Color": { "R": 255, "G": 0, "B": 0, "A": 255 }, "Distance": 50 }
+  ]
 }
 ```
 
-## multi arm position switch
-```
+| Name          | Type   | Required | Description                                                                                                            |
+| ------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `src`         | string | Yes      | Name of the source camera.                                                                                             |
+| `src_frame`   | string | No       | Frame the source point cloud is in. Defaults to the source camera's name. Points are transformed from this to `world`. |
+| `min`         | vector | No       | Lower-bound `(X, Y, Z)` of the crop box in the world frame.                                                            |
+| `max`         | vector | No       | Upper-bound `(X, Y, Z)` of the crop box in the world frame.                                                            |
+| `good_colors` | array  | No       | RGB color filters. A point is kept only if its color is within `Distance` (Euclidean RGB) of every listed `Color`.     |
+
+The cropped point cloud is exposed via `NextPointCloud` and as a 2D PNG via `Images`.
+
+---
+
+## Model: `erh:vmodutils:pc-detect-crop-camera`
+
+**API:** `rdk:component:camera`
+
+Runs a vision service's detector against the source camera, then crops the source point cloud to the union of the detection bounding boxes by projecting points back into the image plane. The source camera **must** publish `IntrinsicParams`.
+
+### Configuration
+
+```json
 {
-    // required
-    "arm" : "<name of arm>",
-
-    // optional - if set uses joint to joint motion via motion.Move, if not uses arm.MoveToJointPositions
-    "motion" : "<name of motion service>",
-
-    // list of arm joint positions
-    // the list needs to contain at least one set of joint positions
-    "joints_list" : [[0, 0, 0, 0, 0, 0], ...],
-
-    // optional - if set, the Geometry objects in the vision services' GetObjectPointClouds results
-    // are added to the world state passed to the motion service
-    "vision_services": ["<name of vision service>"],
-
-    // optional - options passed as 'extra' to motion.Move or arm.MoveToJointPositions
-    "extra" : "<options>",
-
-    // optional - motion constraints passed to motion.Move (only used when motion service is set)
-    "constraints" : < ... >
+  "src": "<string>",
+  "service": "<string>"
 }
 ```
 
-## pc multiple arm poses
-```
-{
- "src" : "<name of camera>",
- "positions" : [ <arm-position-saver>, ... ]
- }
-```
+| Name      | Type   | Required | Description                                               |
+| --------- | ------ | -------- | --------------------------------------------------------- |
+| `src`     | string | Yes      | Name of the source camera. Must expose camera intrinsics. |
+| `service` | string | Yes      | Name of the vision service used for detections.           |
 
-## obstacle
-Configure this with a frame and you can have obstacles on your robot without having to hard code.
-```
-{
- "geometries" : [ { "type" : "box", "x" : 100, "y": 100, "z" : 100 } ]
- "geometries" : [ { "type" : "sphere", "r" : 100 } ]
+---
 
+## Model: `erh:vmodutils:pc-merge`
+
+**API:** `rdk:component:camera`
+
+Pulls one point cloud from each configured source camera and concatenates them into a single output. No transformation is applied — each source's points are kept in their original frame.
+
+### Configuration
+
+```json
+{
+  "cameras": ["<camera1>", "<camera2>"]
 }
 ```
 
-## obstacle open box
-Configure this with a frame and you can have obstacles on your robot without having to hard code.
-```
+| Name      | Type     | Required | Description                                                 |
+| --------- | -------- | -------- | ----------------------------------------------------------- |
+| `cameras` | string[] | Yes      | One or more source camera names. Must contain at least one. |
+
+---
+
+## Model: `erh:vmodutils:pc-look-at-crop-camera`
+
+**API:** `rdk:component:camera`
+
+Finds the point in the source point cloud closest to the camera's centerline (smallest `(X² + Y²)` with `Z > 20`), then grows a connected cluster of nearby points around it using a coarse spatial bucketing. Useful for isolating "the thing in front of the camera" without configuring an explicit crop box.
+
+### Configuration
+
+```json
 {
-  "length" : 10,
-  "width" : 10,
-  "height" : 10,
-  "thickness" : <optional, defaults to 1>,
-  "to_move" : <if you want to move something to grab>,
-  "motion" : <needed it to_move, but will also default to builtin>
+  "src": "<string>",
+  "use_color": false
 }
 ```
 
-## pc look at crop camera
-looks at the center of a point cloud and gets just that
-```
+| Name        | Type   | Required | Description                                                                                                                                                 |
+| ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src`       | string | Yes      | Name of the source camera. Must expose camera intrinsics when `use_color` is `true`.                                                                        |
+| `use_color` | bool   | No       | If `true`, also flood-fills a region in the 2D image around the center pixel by HSV bucket and restricts the point cloud to those pixels before clustering. |
+
+---
+
+## Model: `erh:vmodutils:pc-multiple-arm-poses`
+
+**API:** `rdk:component:camera`
+
+Iterates over a list of switch components (typically `arm-position-saver` or `multi-arm-position-switch`), drives each to its "go to" position, captures a point cloud from the source camera at each pose, transforms each into the world frame, and merges them.
+
+For every switch in `positions`, the model calls `SetPosition(2, ...)` (the "go to" position on `arm-position-saver`) — so any switch wired in must accept index `2` as a "move to saved pose" command.
+
+### Configuration
+
+```json
 {
-    "src" : "<camera>",
-    "use_color" : "<bool>" // optional
+  "src": "<string>",
+  "sleep_seconds": 1.0,
+  "positions": ["<switch1>", "<switch2>"]
 }
 ```
 
-## session capture
-Generic sensor meant to be wired into the data manager's `capture_control_sensor`. Its `Readings` publishes an `overrides` array — one entry per configured component — that the data manager applies to drive capture frequency and tags. `DoCommand` with `{"start-capture": true}` stamps a new session tag (`<prefix><timestamp>`) and turns capture on; `{"stop-capture": true}` zeros the frequency and tags with `<prefix>stopped`.
-```
+| Name            | Type     | Required | Description                                                                                                   |
+| --------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `src`           | string   | Yes      | Source camera. The point cloud captured here will be transformed into the world frame using the frame system. |
+| `sleep_seconds` | float    | No       | Seconds to wait after each move before capturing, to let vibrations settle. Defaults to `1`.                  |
+| `positions`     | string[] | Yes      | Names of switch components to drive. At least one is required.                                                |
+
+`Images` is **not** supported; only `NextPointCloud`.
+
+---
+
+## Model: `erh:vmodutils:pc-cluster`
+
+**API:** `rdk:service:vision`
+
+Vision service that segments a camera's point cloud into spatial clusters: points are bucketed into a 3D grid of `max-distance` cells, each non-empty bucket becomes a segment, and segments whose closest pair of points are within `max-distance` are iteratively merged. Only `GetObjectPointClouds` is implemented — the other vision methods return errors.
+
+### Configuration
+
+```json
 {
-    "components" : [
-        {
-            "resource_name" : "<resource>",
-            "method" : "<capture method>",
-            "capture_frequency_hz" : 10 // optional, defaults to 10
-        }
-    ],
-    "tag_prefix" : "<optional prefix prepended to tags>"
+  "camera": "<string>",
+  "max-distance": 20.0,
+  "min-points-per-segment": 5,
+  "min-points-per-cluster": 50
 }
+```
+
+| Name                     | Type   | Required | Description                                                                     |
+| ------------------------ | ------ | -------- | ------------------------------------------------------------------------------- |
+| `camera`                 | string | Yes      | Source camera providing the point cloud.                                        |
+| `max-distance`           | float  | Yes      | Both the bucket size and the merge threshold (must be `> 0`).                   |
+| `min-points-per-segment` | int    | Yes      | Minimum points a bucket must contain to be considered a candidate segment.      |
+| `min-points-per-cluster` | int    | Yes      | Minimum points a final merged cluster must contain to be returned as an object. |
+
+---
+
+## Model: `erh:vmodutils:arm-position-saver`
+
+**API:** `rdk:component:switch`
+
+A 3-position switch that records and replays a single arm pose. The "saved" pose is stored directly in the component's cloud config — so it persists across reboots — and is replayed via the motion service or directly via the arm.
+
+The switch has three positions:
+
+| Index | Name            | Effect                                                                                                                                            |
+| ----- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | `idle`          | No-op.                                                                                                                                            |
+| 1     | `update config` | Reads the current arm state and writes it back to this component's cloud config (`joints` if `motion` is unset, otherwise `point`+`orientation`). |
+| 2     | `go to`         | Moves the arm to the saved pose. Returns the switch to `idle` on completion.                                                                      |
+
+Replay strategy:
+- If `joints` is set and `motion` is configured → `motion.Move` with joint goals.
+- If `joints` is set and `motion` is unset → `arm.MoveToJointPositions`.
+- If `point`/`orientation` are set and `motion` is configured → cartesian `motion.Move`.
+
+### Configuration
+
+```json
+{
+  "arm": "<string>",
+  "motion": "<string>",
+  "joints": [0, 0, 0, 0, 0, 0],
+  "point": { "X": 0, "Y": 0, "Z": 500 },
+  "orientation": { "OX": 0, "OY": 0, "OZ": 1, "Theta": 0 },
+  "vision_services": ["<string>"],
+  "extra": { },
+  "constraints": { }
+}
+```
+
+| Name              | Type     | Required | Description                                                                                                      |
+| ----------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `arm`             | string   | Yes      | Name of the arm to record and move.                                                                              |
+| `motion`          | string   | No       | Motion service name (typically `"builtin"`). When unset, the switch uses `arm.MoveToJointPositions` directly.    |
+| `joints`          | float[]  | No       | Saved joint positions (radians). Populated automatically by the "update config" position when `motion` is unset. |
+| `point`           | vector   | No       | Saved cartesian point (mm). Populated automatically by "update config" when `motion` is set.                     |
+| `orientation`     | object   | No       | Saved orientation as an `OrientationVectorDegrees` (`OX`, `OY`, `OZ`, `Theta`).                                  |
+| `vision_services` | string[] | No       | Vision services whose `GetObjectPointClouds` results are added to the world state passed to the motion service.  |
+| `extra`           | object   | No       | Arbitrary `extra` map forwarded to `motion.Move` / `arm.MoveToJointPositions`. May not contain `goal_state`.     |
+| `constraints`     | object   | No       | Motion constraints forwarded to `motion.Move` (only used when `motion` is set).                                  |
+
+### DoCommand
+
+**`cfg`** — Return the saved configuration.
+
+```json
+{ "cfg": true }
+```
+
+Returns:
+
+```json
+{
+  "joints": [0, 0, 0, 0, 0, 0],
+  "point": { "X": 0, "Y": 0, "Z": 500 },
+  "orientation": { "OX": 0, "OY": 0, "OZ": 1, "Theta": 0 },
+  "as_json": "<full config as JSON string>"
+}
+```
+
+---
+
+## Model: `erh:vmodutils:multi-arm-position-switch`
+
+**API:** `rdk:component:switch`
+
+A switch with one position per pre-configured joint goal. `SetPosition(i)` moves the arm to `joints_list[i]`. Only one move can be in flight at a time — concurrent calls return an error.
+
+When `write_files_to_capture_directory` is enabled, every move writes the config, goal, and final joint positions to the data-manager capture directory. If a `traceID` is propagated through the request context, files are placed under a `tag=<traceID>` subdirectory.
+
+### Configuration
+
+```json
+{
+  "arm": "<string>",
+  "motion": "<string>",
+  "joints_list": [[0, 0, 0, 0, 0, 0], [1.57, 0, 0, 0, 0, 0]],
+  "vision_services": ["<string>"],
+  "extra": { },
+  "constraints": { },
+  "write_files_to_capture_directory": false
+}
+```
+
+| Name                               | Type      | Required | Description                                                                                                              |
+| ---------------------------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `arm`                              | string    | Yes      | Name of the arm to move.                                                                                                 |
+| `joints_list`                      | float[][] | Yes      | Ordered list of joint goals. The switch exposes `len(joints_list)` positions named `"go to 0"`, `"go to 1"`, …           |
+| `motion`                           | string    | No       | Motion service name (typically `"builtin"`). When unset, uses `arm.MoveToJointPositions`.                                |
+| `vision_services`                  | string[]  | No       | Vision services whose `GetObjectPointClouds` results are added to the world state passed to the motion service.          |
+| `extra`                            | object    | No       | Arbitrary `extra` map forwarded to motion. May not contain `goal_state`.                                                 |
+| `constraints`                      | object    | No       | Motion constraints forwarded to `motion.Move` (only used when `motion` is set).                                          |
+| `write_files_to_capture_directory` | bool      | No       | When `true`, persists config, goal, and actual joint values to the capture directory on every move. Defaults to `false`. |
+
+`DoCommand` is not implemented.
+
+---
+
+## Model: `erh:vmodutils:obstacle`
+
+**API:** `rdk:component:gripper`
+
+Publishes a configurable set of static `spatialmath.Geometry` objects so the motion service treats them as obstacles. Configure this component with a `frame` to position the obstacles in the world. `Grab` and `Open` always return errors — this gripper does not move.
+
+### Configuration
+
+```json
+{
+  "geometries": [
+    { "type": "box", "x": 100, "y": 100, "z": 100 },
+    { "type": "sphere", "r": 100 }
+  ]
+}
+```
+
+| Name         | Type  | Required | Description                                                                                  |
+| ------------ | ----- | -------- | -------------------------------------------------------------------------------------------- |
+| `geometries` | array | Yes      | One or more `spatialmath.GeometryConfig` entries. See the RDK `spatialmath` docs for fields. |
+
+---
+
+## Model: `erh:vmodutils:obstacle-open-box`
+
+**API:** `rdk:component:gripper`
+
+A specialised obstacle gripper that publishes the **five faces of an open-top box** (floor, front, back, left, right) as obstacle geometries. Configure with a `frame` to place the box in the world. Optionally drives a target component (e.g. a real gripper or item) to the box opening via `Grab`.
+
+### Configuration
+
+```json
+{
+  "length": 200,
+  "width": 200,
+  "height": 150,
+  "thickness": 1,
+  "to_move": "<string>",
+  "motion": "<string>",
+  "offset": 50
+}
+```
+
+| Name        | Type   | Required | Description                                                                                                                         |
+| ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `length`    | float  | Yes      | Box length along the X axis (mm).                                                                                                   |
+| `width`     | float  | Yes      | Box width along the Y axis (mm).                                                                                                    |
+| `height`    | float  | Yes      | Box height along the Z axis (mm).                                                                                                   |
+| `thickness` | float  | No       | Wall thickness (mm). Defaults to `1`.                                                                                               |
+| `to_move`   | string | No       | Name of the component to drive into the box opening when `Grab` is called.                                                          |
+| `motion`    | string | No       | Motion service used by `Grab`. Required if `to_move` is set; defaults to `"builtin"`.                                               |
+| `offset`    | float  | No       | Vertical offset (mm) added to the box's world-frame origin when computing the destination of `to_move` in `Grab`. Defaults to `50`. |
+
+`Grab` moves `to_move` to a pose `offset` mm above the box origin, with `OZ = -1` and `Theta` copied from `to_move`'s current orientation, under a 180° orientation constraint. It always returns `false` for "did grab" (the box doesn't actually pick anything up).
+
+---
+
+## Model: `erh:vmodutils:calibration-checker`
+
+**API:** `rdk:component:sensor`
+
+Asks two or more `posetracker` components for the same AprilTag, transforms each tracker's reported tag pose into the world frame using the frame system, and computes the maximum pairwise distance between the resulting points. If the distance exceeds `tolerance_mm`, the reading flags a calibration failure.
+
+Useful for detecting arm or camera drift: if multiple cameras observe the same fiducial, all transforms should agree on its world-frame position.
+
+### Configuration
+
+```json
+{
+  "pose_trackers": ["<tracker1>", "<tracker2>"],
+  "tag_id": "0",
+  "tolerance_mm": 10
+}
+```
+
+| Name            | Type     | Required | Description                                                                                           |
+| --------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `pose_trackers` | string[] | Yes      | At least **two** pose-tracker component names that should all see the same tag.                       |
+| `tag_id`        | string   | No       | Tag identifier to look up in each tracker's `Poses` result. Defaults to `"0"`.                        |
+| `tolerance_mm`  | float    | No       | Maximum allowed pairwise distance (mm) between trackers' world-frame tag positions. Defaults to `10`. |
+
+### Readings
+
+`Readings` (and `DoCommand` with any payload) returns a flat map containing, for each tracker:
+
+- `<tracker>_visible`: bool — whether the tag was reported.
+- `<tracker>_frame`: string — parent frame of the reported tag pose.
+- `<tracker>_x` / `_y` / `_z`: float — world-frame coordinates (mm).
+- `<tracker>_error` / `<tracker>_transform_error`: string — error message if the tracker call or frame-system transform failed.
+
+Plus the aggregate fields:
+
+```json
+{
+  "max_distance_mm": 7.3,
+  "tolerance_mm": 10,
+  "calibration_ok": true
+}
+```
+
+When `calibration_ok` is `false`, an `error` field is included describing which two trackers diverged the most. When fewer than two trackers see the tag, `calibration_ok` is `true` and a `reason` field explains the skip.
+
+---
+
+## Model: `erh:vmodutils:session-capture`
+
+**API:** `rdk:component:sensor`
+
+A "session control" sensor designed to be wired into the data manager's `capture_control_sensor`. When inactive, `Readings` returns just `{"active": false}` and the data manager applies no overrides — capture is effectively off. When active, `Readings` publishes an `overrides` array (one entry per configured component) telling the data manager to capture each at its configured frequency, tagged with the current session id.
+
+Session ids are generated from the local clock at start time as `<tag_prefix><YYYYMMDD_HHMMSS.mmm>`.
+
+### Configuration
+
+```json
+{
+  "components": [
+    { "resource_name": "my-cam", "method": "ReadImage", "capture_frequency_hz": 5 },
+    { "resource_name": "my-arm", "method": "EndPosition" }
+  ],
+  "tag_prefix": "session_"
+}
+```
+
+| Name         | Type   | Required | Description                                                                                                          |
+| ------------ | ------ | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `components` | array  | Yes      | One or more capture targets. Each entry needs `resource_name` and `method`; `capture_frequency_hz` defaults to `10`. |
+| `tag_prefix` | string | No       | Prefix prepended to the timestamped session id. Defaults to empty.                                                   |
+
+Each entry in `components`:
+
+| Name                   | Type   | Required | Description                                                               |
+| ---------------------- | ------ | -------- | ------------------------------------------------------------------------- |
+| `resource_name`        | string | Yes      | Name of the component to capture from.                                    |
+| `method`               | string | Yes      | Capture method (e.g. `"ReadImage"`, `"NextPointCloud"`, `"EndPosition"`). |
+| `capture_frequency_hz` | float  | No       | Capture frequency override. Defaults to `10`.                             |
+
+### Readings
+
+When inactive:
+
+```json
+{ "active": false }
+```
+
+When active:
+
+```json
+{
+  "active": true,
+  "overrides": [
+    {
+      "resource_name": "my-cam",
+      "method": "ReadImage",
+      "capture_frequency_hz": 5,
+      "tags": ["session_20260501_120000.000"]
+    }
+  ]
+}
+```
+
+### DoCommand
+
+**`start`** — Begin a new capture session. Stamps a fresh `<tag_prefix><timestamp>` tag and flips `active` to `true`.
+
+```json
+{ "start": true }
+```
+
+Returns:
+
+```json
+{ "status": "capturing", "tags": ["session_20260501_120000.000"] }
+```
+
+**`stop`** — End the current session. Flips `active` to `false` and clears the tag list, so subsequent `Readings` calls return only `{"active": false}`.
+
+```json
+{ "stop": true }
+```
+
+Returns:
+
+```json
+{ "status": "stopped" }
 ```

--- a/meta.json
+++ b/meta.json
@@ -8,72 +8,75 @@
     {
         "api": "rdk:component:camera",
         "model": "erh:vmodutils:pc-crop-camera",
-        "markdown_link": "README.md#pc-crop-camera",
+        "markdown_link": "README.md#model-erhvmodutilspc-crop-camera",
         "short_description": "crops a pointcloud"
     },
     {
         "api": "rdk:component:camera",
         "model": "erh:vmodutils:pc-detect-crop-camera",
-        "markdown_link": "README.md#pc-detect-crop-camera",
+        "markdown_link": "README.md#model-erhvmodutilspc-detect-crop-camera",
         "short_description": "crops a pointcloud based on vision detections"
     },
     {
         "api": "rdk:component:camera",
         "model": "erh:vmodutils:pc-merge",
-        "markdown_link": "README.md#pc-merge",
+        "markdown_link": "README.md#model-erhvmodutilspc-merge",
         "short_description": "merges pointclouds"
     },
 
     {
         "api": "rdk:component:camera",
         "model": "erh:vmodutils:pc-multiple-arm-poses",
-        "markdown_link": "README.md#pc-multiple-arm-poses",
+        "markdown_link": "README.md#model-erhvmodutilspc-multiple-arm-poses",
         "short_description": "moves an arm to multiple positions and merges pointcloud"
     },
     {
         "api": "rdk:component:switch",
         "model": "erh:vmodutils:arm-position-saver",
-        "markdown_link": "README.md#arm-position-saver",
+        "markdown_link": "README.md#model-erhvmodutilsarm-position-saver",
         "short_description": "saves an arm position and let's you go there"
     },
     {
         "api": "rdk:component:gripper",
         "model": "erh:vmodutils:obstacle",
-        "markdown_link": "README.md#obstacle",
+        "markdown_link": "README.md#model-erhvmodutilsobstacle",
         "short_description": "obstacle, doesn't do anything but get in the way"
     },
     {
         "api": "rdk:component:gripper",
         "model": "erh:vmodutils:obstacle-open-box",
-        "markdown_link": "README.md#obstacle-open-box",
+        "markdown_link": "README.md#model-erhvmodutilsobstacle-open-box",
         "short_description": "open box obstacle, doesn't do anything but get in the way"
     },
     {
         "api": "rdk:service:vision",
-        "model": "erh:vmodutils:pc-cluster"
+        "model": "erh:vmodutils:pc-cluster",
+        "markdown_link": "README.md#model-erhvmodutilspc-cluster",
+        "short_description": "segments a camera's pointcloud into spatial clusters"
     },
     {
         "api": "rdk:component:camera",
         "model": "erh:vmodutils:pc-look-at-crop-camera",
-        "markdown_link": "README.md#pc-look-at-crop-camera",
+        "markdown_link": "README.md#model-erhvmodutilspc-look-at-crop-camera",
         "short_description": "looks at the center of a point cloud and gets just that"
 
     },
     {
         "api": "rdk:component:switch",
         "model": "erh:vmodutils:multi-arm-position-switch",
-        "markdown_link": "README.md#multi-arm-position-switch",
+        "markdown_link": "README.md#model-erhvmodutilsmulti-arm-position-switch",
         "short_description": "allows configuring a list of arm positions and going to a position by index in the list"
     },
     {
         "api": "rdk:component:sensor",
         "model": "erh:vmodutils:calibration-checker",
+        "markdown_link": "README.md#model-erhvmodutilscalibration-checker",
         "short_description": "compares world-frame tag positions across 2+ pose trackers to detect arm drift"
     },
     {
         "api": "rdk:component:sensor",
         "model": "erh:vmodutils:session-capture",
-        "markdown_link": "README.md#session-capture",
+        "markdown_link": "README.md#model-erhvmodutilssession-capture",
         "short_description": "switch that toggles data-capture overrides for a list of components, tagging them with a session id"
     }
   ],


### PR DESCRIPTION
## Summary

Replace the previous snippet-only README with more complete reference for every model in the module, and wire the `meta.json` `markdown_link` fields to the new README anchors so each resource page on the Viam app deep-links correctly.

## Changes

- **README.md**: Add an overview list of all 12 models, then a `## Model:` section per resource with:
  -  API, description
  - JSON config example,
  - config table (Name / Type / Required / Description, including defaults and validation), 
  - `DoCommand` where applicable. 

- **meta.json**: Point every model's `markdown_link` at its new README anchor (e.g. `README.md#model-erhvmodutilspc-crop-camera`). 

## Testing

Documentation-only change — no code paths affected. Reviewer should:
- [x] Spot-checked that each `markdown_link` in `meta.json` resolves to the matching `## Model:` heading in `README.md`.
- [x] Sanity-checked the documented config fields, defaults, and DoCommand behaviour against the source for at least one model.