### PR TITLE
goal joints follow full movable chain above arm

### DIFF
--- a/touch/arm_position_saver.go
+++ b/touch/arm_position_saver.go
@@ -12,6 +12,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
 	"go.viam.com/rdk/resource"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
 	"go.viam.com/rdk/services/vision"
@@ -213,7 +214,8 @@ func (aps *ArmPositionSaver) saveCurrentPosition(ctx context.Context) error {
 func (aps *ArmPositionSaver) goToSavePosition(ctx context.Context) error {
 	if len(aps.cfg.Joints) > 0 {
 		if aps.motion != nil {
-			return goToPositionUsingJointToJointMotion(ctx, aps.cfg.Joints, aps.arm.Name().Name, aps.motion, aps.visionServices, aps.cfg.Extra, aps.cfg.Constraints, aps.logger)
+			goal := referenceframe.FrameSystemInputs{aps.arm.Name().Name: floatsToInputs(aps.cfg.Joints)}
+			return goToPositionUsingJointToJointMotion(ctx, goal, aps.arm.Name().Name, aps.motion, aps.visionServices, aps.cfg.Extra, aps.cfg.Constraints, aps.logger)
 		} else {
 			return goToPositionUsingMoveToJointPositions(ctx, aps.cfg.Joints, aps.arm, aps.cfg.Extra, aps.logger)
 		}

--- a/touch/multi_arm_position_switch.go
+++ b/touch/multi_arm_position_switch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,6 +13,7 @@ import (
 	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/motionplan"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
@@ -66,6 +68,16 @@ func (c *MultiArmPositionSwitchConfig) Validate(path string) ([]string, []string
 		return nil, nil, ErrMustSpecifyAtLeastOneJointPosition
 	}
 
+	firstLen := len(c.JointsList[0])
+	for i := 1; i < len(c.JointsList); i++ {
+		if len(c.JointsList[i]) != firstLen {
+			return nil, nil, fmt.Errorf(
+				"joints_list entries must all have the same inner length; entry 0 has length %d but entry %d has length %d",
+				firstLen, i, len(c.JointsList[i]),
+			)
+		}
+	}
+
 	if c.Extra != nil && c.Extra[extraParamsKeyGoalState] != nil {
 		return nil, nil, ErrCannotSpecifyGoalStateInExtra
 	}
@@ -111,6 +123,35 @@ func newMultiArmPositionSwitch(ctx context.Context, deps resource.Dependencies, 
 		return nil, err
 	}
 
+	fs, err := framesystem.NewFromService(ctx, maps.fsSvc, nil)
+	if err != nil {
+		return nil, fmt.Errorf("multi-arm-position-switch: building frame system: %w", err)
+	}
+	maps.inputChain, err = movableAncestors(fs, arm.Name().Name)
+	if err != nil {
+		return nil, err
+	}
+
+	dofMappingSummary := formatDoFMapping(maps.inputChain)
+
+	maps.logger.Infof("multi-arm-position-switch joint chain (arm first, toward world): %s",
+		dofMappingSummary)
+
+	wantLen := totalDoF(maps.inputChain)
+	for i, row := range newConf.JointsList {
+		if len(row) != wantLen {
+			return nil, fmt.Errorf("joints_list[%d]: length is %d but expected %d (%s)",
+				i, len(row), wantLen, dofMappingSummary)
+		}
+	}
+	if newConf.Motion == "" && len(maps.inputChain) > 1 {
+		return nil, fmt.Errorf(
+			"multi-arm-position-switch: motion service is required when the arm has input-enabled ancestors (%s); "+
+				"configure \"motion\" or use MoveToJointPositions only with an arm-only frame chain",
+			dofMappingSummary,
+		)
+	}
+
 	return maps, nil
 }
 
@@ -126,6 +167,7 @@ type MultiArmPositionSwitch struct {
 	motion         motion.Service
 	visionServices []vision.Service
 	fsSvc          framesystem.Service
+	inputChain     []referenceframe.Frame
 
 	// 'mu' protects access to 'position'
 	mu       sync.Mutex
@@ -212,7 +254,11 @@ func (maps *MultiArmPositionSwitch) goToPosition(ctx context.Context, position u
 
 	var moveErr error
 	if maps.motion != nil {
-		moveErr = goToPositionUsingJointToJointMotion(ctx, joints, maps.arm.Name().Name, maps.motion, maps.visionServices, maps.cfg.Extra, maps.cfg.Constraints, maps.logger)
+		goalInputs, err := flatJointsToGoalInputs(joints, maps.inputChain)
+		if err != nil {
+			return err
+		}
+		moveErr = goToPositionUsingJointToJointMotion(ctx, goalInputs, maps.arm.Name().Name, maps.motion, maps.visionServices, maps.cfg.Extra, maps.cfg.Constraints, maps.logger)
 	} else {
 		moveErr = goToPositionUsingMoveToJointPositions(ctx, joints, maps.arm, maps.cfg.Extra, maps.logger)
 	}
@@ -230,4 +276,72 @@ func (maps *MultiArmPositionSwitch) goToPosition(ctx context.Context, position u
 	}
 
 	return moveErr
+}
+
+func movableAncestors(fs *referenceframe.FrameSystem, armFrameName string) ([]referenceframe.Frame, error) {
+	armFrame := fs.Frame(armFrameName)
+	if armFrame == nil {
+		return nil, fmt.Errorf(
+			"multi-arm-position-switch: arm %q is not in the frame system; check the arm's name matches the frame system",
+			armFrameName,
+		)
+	}
+	path, err := fs.TracebackFrame(armFrame)
+	if err != nil {
+		return nil, fmt.Errorf("multi-arm-position-switch: tracing frame %q toward world: %w", armFrameName, err)
+	}
+
+	var chain []referenceframe.Frame
+	for _, fr := range path {
+		if fr.Name() == referenceframe.World {
+			continue
+		}
+		if len(fr.DoF()) > 0 {
+			chain = append(chain, fr)
+		}
+	}
+	return chain, nil
+}
+
+func totalDoF(frames []referenceframe.Frame) int {
+	n := 0
+	for _, fr := range frames {
+		n += len(fr.DoF())
+	}
+	return n
+}
+
+func formatDoFMapping(frames []referenceframe.Frame) string {
+	var b strings.Builder
+	offset := 0
+	for i, fr := range frames {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		dof := len(fr.DoF())
+		if dof == 1 {
+			fmt.Fprintf(&b, "%s[%d]", fr.Name(), offset)
+		} else {
+			fmt.Fprintf(&b, "%s[%d:%d]", fr.Name(), offset, offset+dof)
+		}
+		offset += dof
+	}
+	return b.String()
+}
+
+func flatJointsToGoalInputs(joints []float64, chain []referenceframe.Frame) (referenceframe.FrameSystemInputs, error) {
+	want := totalDoF(chain)
+	if len(joints) != want {
+		return nil, fmt.Errorf("internal error: got %d joint values for %d expected (mapping: %s)",
+			len(joints), want, formatDoFMapping(chain))
+	}
+	out := make(referenceframe.FrameSystemInputs)
+	off := 0
+	for _, fr := range chain {
+		d := len(fr.DoF())
+		slice := joints[off : off+d]
+		out[fr.Name()] = floatsToInputs(slice)
+		off += d
+	}
+	return out, nil
 }

--- a/touch/multi_arm_position_switch_test.go
+++ b/touch/multi_arm_position_switch_test.go
@@ -3,13 +3,18 @@ package touch
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"testing"
 
+	"github.com/golang/geo/r3"
 	toggleswitch "go.viam.com/rdk/components/switch"
 	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/referenceframe"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/services/motion"
+	"go.viam.com/rdk/spatialmath"
 	"go.viam.com/rdk/testutils/inject"
 	injectMotion "go.viam.com/rdk/testutils/inject/motion"
 	"go.viam.com/rdk/vision"
@@ -127,6 +132,9 @@ func TestMultiArmPositionSwitchSetPositionAndGetPosition(t *testing.T) {
 		}
 
 		fakeFsSvc := inject.NewFrameSystemService(framesystem.PublicServiceName.Name)
+		fakeFsSvc.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
+			return mustTestFSConfigArm3DOF(t), nil
+		}
 
 		allDeps := resource.Dependencies{
 			fakeArm.Name():     fakeArm,
@@ -213,6 +221,9 @@ func TestMultiArmPositionSwitchSetPositionAndGetPosition(t *testing.T) {
 		}
 
 		fakeFsSvc := inject.NewFrameSystemService(framesystem.PublicServiceName.Name)
+		fakeFsSvc.FrameSystemConfigFunc = func(ctx context.Context) (*framesystem.Config, error) {
+			return mustTestFSConfigArm3DOF(t), nil
+		}
 
 		allDeps := resource.Dependencies{
 			fakeArm.Name():   fakeArm,
@@ -269,4 +280,142 @@ func TestMultiArmPositionSwitchSetPositionAndGetPosition(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, position, test.ShouldEqual, 0)
 	})
+}
+
+func mustTestFSConfigArm3DOF(t *testing.T) *framesystem.Config {
+	t.Helper()
+	internal := referenceframe.NewEmptyFrameSystem("internal")
+	var parent referenceframe.Frame = internal.World()
+	var last string
+	for i := 0; i < 3; i++ {
+		nm := fmt.Sprintf("j%d", i)
+		j, err := referenceframe.NewRotationalFrame(
+			nm,
+			spatialmath.R4AA{RX: 1},
+			referenceframe.Limit{Min: -math.Pi, Max: math.Pi},
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, internal.AddFrame(j, parent), test.ShouldBeNil)
+		parent = j
+		last = nm
+	}
+	m, err := referenceframe.NewModel("arm", internal, last)
+	test.That(t, err, test.ShouldBeNil)
+	lif := referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "arm", nil)
+	return &framesystem.Config{Parts: []*referenceframe.FrameSystemPart{{FrameConfig: lif, ModelFrame: m}}}
+}
+
+func mustTestFSConfigArmUnderGantry(t *testing.T) *framesystem.Config {
+	t.Helper()
+	gInternal := referenceframe.NewEmptyFrameSystem("g")
+	gf, err := referenceframe.NewTranslationalFrame(
+		"axis",
+		r3.Vector{X: 1},
+		referenceframe.Limit{Min: 0, Max: 2},
+	)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gInternal.AddFrame(gf, gInternal.World()), test.ShouldBeNil)
+	gantryModel, err := referenceframe.NewModel("gantry", gInternal, "axis")
+	test.That(t, err, test.ShouldBeNil)
+	gantryLink := referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "gantry", nil)
+
+	internal := referenceframe.NewEmptyFrameSystem("internal")
+	var parent referenceframe.Frame = internal.World()
+	var last string
+	for i := 0; i < 2; i++ {
+		nm := fmt.Sprintf("j%d", i)
+		j, err := referenceframe.NewRotationalFrame(
+			nm,
+			spatialmath.R4AA{RX: 1},
+			referenceframe.Limit{Min: -math.Pi, Max: math.Pi},
+		)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, internal.AddFrame(j, parent), test.ShouldBeNil)
+		parent = j
+		last = nm
+	}
+	armModel, err := referenceframe.NewModel("arm", internal, last)
+	test.That(t, err, test.ShouldBeNil)
+	armLink := referenceframe.NewLinkInFrame("gantry", spatialmath.NewZeroPose(), "arm", nil)
+
+	return &framesystem.Config{Parts: []*referenceframe.FrameSystemPart{
+		{FrameConfig: gantryLink, ModelFrame: gantryModel},
+		{FrameConfig: armLink, ModelFrame: armModel},
+	}}
+}
+
+func TestMovableAncestors(t *testing.T) {
+	t.Run("arm only (3 DoF model)", func(t *testing.T) {
+		cfg := mustTestFSConfigArm3DOF(t)
+		fs, err := referenceframe.NewFrameSystem(framesystem.LocalFrameSystemName, cfg.Parts, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		chain, err := movableAncestors(fs, "arm")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(chain), test.ShouldEqual, 1)
+		test.That(t, chain[0].Name(), test.ShouldEqual, "arm")
+		test.That(t, len(chain[0].DoF()), test.ShouldEqual, 3)
+	})
+
+	t.Run("gantry + arm", func(t *testing.T) {
+		cfg := mustTestFSConfigArmUnderGantry(t)
+		fs, err := referenceframe.NewFrameSystem(framesystem.LocalFrameSystemName, cfg.Parts, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		chain, err := movableAncestors(fs, "arm")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(chain), test.ShouldEqual, 2)
+		test.That(t, chain[0].Name(), test.ShouldEqual, "arm")
+		test.That(t, chain[1].Name(), test.ShouldEqual, "gantry")
+	})
+
+	t.Run("static ancestor skipped (table has 0 DoF)", func(t *testing.T) {
+		table := referenceframe.NewLinkInFrame(referenceframe.World, spatialmath.NewZeroPose(), "table", nil)
+		base := mustTestFSConfigArmUnderGantry(t)
+		gantryPart := base.Parts[0]
+		gantryPart.FrameConfig = referenceframe.NewLinkInFrame("table", spatialmath.NewZeroPose(), "gantry", nil)
+		parts := []*referenceframe.FrameSystemPart{
+			{FrameConfig: table, ModelFrame: nil},
+			gantryPart,
+			base.Parts[1],
+		}
+		fs, err := referenceframe.NewFrameSystem(framesystem.LocalFrameSystemName, parts, nil)
+		test.That(t, err, test.ShouldBeNil)
+
+		chain, err := movableAncestors(fs, "arm")
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, len(chain), test.ShouldEqual, 2)
+		test.That(t, chain[1].Name(), test.ShouldEqual, "gantry")
+	})
+}
+
+func TestFlatJointsToGoalInputs(t *testing.T) {
+	cfg := mustTestFSConfigArmUnderGantry(t)
+	fs, err := referenceframe.NewFrameSystem(framesystem.LocalFrameSystemName, cfg.Parts, nil)
+	test.That(t, err, test.ShouldBeNil)
+	chain, err := movableAncestors(fs, "arm")
+	test.That(t, err, test.ShouldBeNil)
+
+	got, err := flatJointsToGoalInputs([]float64{1, 2, 3}, chain)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(got), test.ShouldEqual, 2)
+	test.That(t, []float64(got["arm"]), test.ShouldResemble, []float64{1, 2})
+	test.That(t, []float64(got["gantry"]), test.ShouldResemble, []float64{3})
+
+	_, err = flatJointsToGoalInputs([]float64{1, 2}, chain)
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestMultiArmPositionSwitchValidateUniformLength(t *testing.T) {
+	path := "components.0"
+	cfg := &MultiArmPositionSwitchConfig{
+		Arm: "arm",
+		JointsList: [][]float64{
+			{0, 0, 0},
+			{1, 1},
+		},
+	}
+	_, _, err := cfg.Validate(path)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "same inner length")
 }

--- a/touch/utils.go
+++ b/touch/utils.go
@@ -359,7 +359,7 @@ func buildWorldStateWithObstacles(ctx context.Context, visionSvcs []vision.Servi
 
 func goToPositionUsingJointToJointMotion(
 	ctx context.Context,
-	joints []float64,
+	goalFrameSystemInputs referenceframe.FrameSystemInputs,
 	armName string,
 	motionSvc motion.Service,
 	visionSvcs []vision.Service,
@@ -375,10 +375,6 @@ func goToPositionUsingJointToJointMotion(
 	if err != nil {
 		return err
 	}
-
-	// Express the goal state in joint positions
-	goalFrameSystemInputs := make(referenceframe.FrameSystemInputs)
-	goalFrameSystemInputs[armName] = joints
 	if extra == nil {
 		extra = make(map[string]any)
 	} else if extra[extraParamsKeyGoalState] != nil {
@@ -477,6 +473,14 @@ func serialize(inputs referenceframe.FrameSystemInputs) map[string]any {
 	}
 	m["configuration"] = confMap
 	return m
+}
+
+func floatsToInputs(j []float64) []referenceframe.Input {
+	out := make([]referenceframe.Input, len(j))
+	for i, v := range j {
+		out[i] = v
+	}
+	return out
 }
 
 func GetMergedPointCloudFromMultiPositionSwitch(ctx context.Context, s toggleswitch.Switch, sleepTime time.Duration, srcCamera camera.Camera, extraForCamera map[string]any, fsSvc framesystem.Service, writeFilesToCaptureDirectory bool) (pointcloud.PointCloud, error) {


### PR DESCRIPTION
joints_list inner vectors are now the concatenated joint targets for every movable frame on the path from the configured arm up to world

**Not a breaking change**

# Manual Testing
Tested against the gantry in the anex