### PR TITLE
pc-crop-camera: use $framesystem dep instead of dialing back to the machine

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -13,6 +13,7 @@ import (
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/utils"
+	"go.viam.com/utils/rpc"
 )
 
 func MachineToDependencies(client robot.Robot) (resource.Dependencies, error) {
@@ -35,6 +36,33 @@ func MachineToDependencies(client robot.Robot) (resource.Dependencies, error) {
 	deps[framesystem.PublicServiceName] = r
 
 	return deps, nil
+}
+
+func ConnectToMachineFromEnv(ctx context.Context, logger logging.Logger) (robot.Robot, error) {
+	params := []string{}
+	for _, pp := range []string{utils.MachineFQDNEnvVar, utils.APIKeyIDEnvVar, utils.APIKeyEnvVar} {
+		x := os.Getenv(pp)
+		if x == "" {
+			return nil, fmt.Errorf("no environment variable for %s", pp)
+		}
+		params = append(params, x)
+	}
+	return ConnectToMachine(ctx, logger, params[0], params[1], params[2])
+}
+
+func ConnectToMachine(ctx context.Context, logger logging.Logger, host, apiKeyId, apiKey string) (robot.Robot, error) {
+	return client.New(
+		ctx,
+		host,
+		logger,
+		client.WithDialOptions(rpc.WithEntityCredentials(
+			apiKeyId,
+			rpc.Credentials{
+				Type:    rpc.CredentialsTypeAPIKey,
+				Payload: apiKey,
+			},
+		)),
+	)
 }
 
 // ConnectToHostFromCLIToken uses the viam cli token to login to a machine with just a hostname.

--- a/machine.go
+++ b/machine.go
@@ -13,7 +13,6 @@ import (
 	"go.viam.com/rdk/robot/client"
 	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/utils"
-	"go.viam.com/utils/rpc"
 )
 
 func MachineToDependencies(client robot.Robot) (resource.Dependencies, error) {
@@ -36,33 +35,6 @@ func MachineToDependencies(client robot.Robot) (resource.Dependencies, error) {
 	deps[framesystem.PublicServiceName] = r
 
 	return deps, nil
-}
-
-func ConnectToMachineFromEnv(ctx context.Context, logger logging.Logger) (robot.Robot, error) {
-	params := []string{}
-	for _, pp := range []string{utils.MachineFQDNEnvVar, utils.APIKeyIDEnvVar, utils.APIKeyEnvVar} {
-		x := os.Getenv(pp)
-		if x == "" {
-			return nil, fmt.Errorf("no environment variable for %s", pp)
-		}
-		params = append(params, x)
-	}
-	return ConnectToMachine(ctx, logger, params[0], params[1], params[2])
-}
-
-func ConnectToMachine(ctx context.Context, logger logging.Logger, host, apiKeyId, apiKey string) (robot.Robot, error) {
-	return client.New(
-		ctx,
-		host,
-		logger,
-		client.WithDialOptions(rpc.WithEntityCredentials(
-			apiKeyId,
-			rpc.Credentials{
-				Type:    rpc.CredentialsTypeAPIKey,
-				Payload: apiKey,
-			},
-		)),
-	)
 }
 
 // ConnectToHostFromCLIToken uses the viam cli token to login to a machine with just a hostname.

--- a/touch/pc_crop_camera.go
+++ b/touch/pc_crop_camera.go
@@ -13,7 +13,7 @@ import (
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/pointcloud"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/robot"
+	"go.viam.com/rdk/robot/framesystem"
 	"go.viam.com/rdk/spatialmath"
 
 	"github.com/erh/vmodutils"
@@ -66,7 +66,11 @@ func newCropCamera(ctx context.Context, deps resource.Dependencies, config resou
 		return nil, err
 	}
 
-	cc.client, err = vmodutils.ConnectToMachineFromEnv(ctx, logger)
+	// The crop camera only needs the robot's frame system to transform point clouds.
+	// Every module is handed a $framesystem dependency backed by its existing local
+	// connection to the parent viam-server, so use that instead of dialing a whole
+	// robot client back to our own machine (which would relay through TURN/coturn).
+	cc.fs, err = framesystem.FromDependencies(deps)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +85,8 @@ type cropCamera struct {
 	cfg    *CropCameraConfig
 	logger logging.Logger
 
-	src    camera.Camera
-	client robot.Robot
+	src camera.Camera
+	fs  framesystem.Service
 
 	lock               sync.Mutex
 	active             bool
@@ -193,7 +197,7 @@ func (cc *cropCamera) doNextPointCloud(ctx context.Context, extra map[string]int
 		srcFrame = cc.cfg.SrcFrame
 	}
 
-	pc, err = cc.client.TransformPointCloud(ctx, pc, srcFrame, "world")
+	pc, err = cc.fs.TransformPointCloud(ctx, pc, srcFrame, "world")
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +208,7 @@ func (cc *cropCamera) doNextPointCloud(ctx context.Context, extra map[string]int
 	timeC := time.Since(start)
 
 	if cc.cfg.TransformBackToSourceFrame {
-		pc, err = cc.client.TransformPointCloud(ctx, pc, "world", srcFrame)
+		pc, err = cc.fs.TransformPointCloud(ctx, pc, "world", srcFrame)
 		if err != nil {
 			return nil, err
 		}
@@ -234,7 +238,9 @@ func (cc *cropCamera) Properties(ctx context.Context) (camera.Properties, error)
 }
 
 func (cc *cropCamera) Close(ctx context.Context) error {
-	return cc.client.Close(ctx)
+	// Nothing to close: the frame system client is backed by the module's existing
+	// connection to the parent viam-server, whose lifecycle the module SDK owns.
+	return nil
 }
 
 func (cc *cropCamera) Geometries(ctx context.Context, _ map[string]interface{}) ([]spatialmath.Geometry, error) {

--- a/touch/pc_crop_camera.go
+++ b/touch/pc_crop_camera.go
@@ -66,10 +66,6 @@ func newCropCamera(ctx context.Context, deps resource.Dependencies, config resou
 		return nil, err
 	}
 
-	// The crop camera only needs the robot's frame system to transform point clouds.
-	// Every module is handed a $framesystem dependency backed by its existing local
-	// connection to the parent viam-server, so use that instead of dialing a whole
-	// robot client back to our own machine (which would relay through TURN/coturn).
 	cc.fs, err = framesystem.FromDependencies(deps)
 	if err != nil {
 		return nil, err
@@ -238,8 +234,6 @@ func (cc *cropCamera) Properties(ctx context.Context) (camera.Properties, error)
 }
 
 func (cc *cropCamera) Close(ctx context.Context) error {
-	// Nothing to close: the frame system client is backed by the module's existing
-	// connection to the parent viam-server, whose lifecycle the module SDK owns.
 	return nil
 }
 


### PR DESCRIPTION
## Description

`newCropCamera` opens a full WebRTC robot client back to its own machine via `vmodutils.ConnectToMachineFromEnv(...)`, solely to call `TransformPointCloud`. That handle is held for the component's whole lifetime.

A TURN allocation is gathered as part of ICE, and that allocation is kept alive for the entirety of the resource's lifetime, regardless if we are transmitting data over the relay path. The TURN credentials minted by the signaling server are time-limited (24h TTL). Once they expire the module's stderr fills with:

```
turnc ERROR: ... Fail to refresh permissions: CreatePermission error response (error 401: Unauthorized)
```

## Fix

For point cloud crop camera to call `TransformPointCloud` it just needs a framesystem dependency, so I just swapped the full robot client for a framesystem dependency resolution backed by its existing local connection to the parent `viam-server` and thread that through instead. 

Behavior is otherwise identical. A more complete solution to handle long lived relay connection is WIP.