### PR TITLE
Add crop_in_local_frame option to pc-crop camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `erh:vmodutils` module bundles a few utility models for arm-based automation
 
 **API:** `rdk:component:camera`
 
-Wraps a source camera and crops its point cloud to an axis-aligned bounding box specified in the **world frame**. Optionally filters points by RGB color similarity.
+Wraps a source camera and crops its point cloud to an axis-aligned bounding box. By default the box is specified in the **world frame**; set `crop_in_local_frame` to apply it in the source camera's local frame instead. Optionally filters points by RGB color similarity.
 
 ### Configuration
 
@@ -39,7 +39,8 @@ Wraps a source camera and crops its point cloud to an axis-aligned bounding box 
     { "Color": { "R": 255, "G": 0, "B": 0, "A": 255 }, "Distance": 50 }
   ],
   "transform_back_to_source_frame": false,
-  "forward_source_images": false
+  "forward_source_images": false,
+  "crop_in_local_frame": false
 }
 ```
 
@@ -47,11 +48,12 @@ Wraps a source camera and crops its point cloud to an axis-aligned bounding box 
 | -------------------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src`                            | string | Yes      | Name of the source camera.                                                                                                                                                                                             |
 | `src_frame`                      | string | No       | Frame the source point cloud is in. Defaults to the source camera's name. Points are transformed from this to `world`.                                                                                                 |
-| `min`                            | vector | No       | Lower-bound `(X, Y, Z)` of the crop box in the world frame.                                                                                                                                                            |
-| `max`                            | vector | No       | Upper-bound `(X, Y, Z)` of the crop box in the world frame.                                                                                                                                                            |
+| `min`                            | vector | No       | Lower-bound `(X, Y, Z)` of the crop box, in the world frame (or the source camera's local frame when `crop_in_local_frame` is `true`).                                                                                  |
+| `max`                            | vector | No       | Upper-bound `(X, Y, Z)` of the crop box, in the world frame (or the source camera's local frame when `crop_in_local_frame` is `true`).                                                                                  |
 | `good_colors`                    | array  | No       | RGB color filters. A point is kept only if its color is within `Distance` (Euclidean RGB) of every listed `Color`.                                                                                                     |
 | `transform_back_to_source_frame` | bool   | No       | If `true`, after cropping in world coordinates the point cloud is transformed back into `src_frame`, and `Properties` forwards the source camera's `IntrinsicParams` / `DistortionParams`. Defaults to `false`.        |
 | `forward_source_images`          | bool   | No       | If `true`, `Images` appends the source camera's `NamedImage`s after the `cropped` image so downstream consumers expecting `color` / `depth` still get them. Defaults to `false`.                                       |
+| `crop_in_local_frame`            | bool   | No       | If `true`, the `min`/`max` box is applied in the source camera's local frame and the `world` transform is skipped; `Properties` forwards the source camera's `IntrinsicParams` / `DistortionParams`. Cannot be combined with `transform_back_to_source_frame`. Defaults to `false`. |
 
 The cropped point cloud is exposed via `NextPointCloud`. `Images` returns the cropped 2D PNG as the first `NamedImage` (named `cropped`); when `forward_source_images` is `true` it is followed by whatever the source camera's `Images` call returns.
 

--- a/touch/pc_crop_camera.go
+++ b/touch/pc_crop_camera.go
@@ -40,11 +40,18 @@ type CropCameraConfig struct {
 
 	TransformBackToSourceFrame bool `json:"transform_back_to_source_frame"`
 	ForwardSourceImages        bool `json:"forward_source_images"`
+
+	// CropInLocalFrame, when true, applies the Min/Max crop box in the source
+	// camera's local frame and skips conversion to/from the world frame.
+	CropInLocalFrame bool `json:"crop_in_local_frame"`
 }
 
 func (ccc *CropCameraConfig) Validate(path string) ([]string, []string, error) {
 	if ccc.Src == "" {
 		return nil, nil, fmt.Errorf("need a src camera")
+	}
+	if ccc.CropInLocalFrame && ccc.TransformBackToSourceFrame {
+		return nil, nil, fmt.Errorf("cannot set both crop_in_local_frame and transform_back_to_source_frame")
 	}
 	return []string{ccc.Src}, nil, nil
 }
@@ -193,9 +200,11 @@ func (cc *cropCamera) doNextPointCloud(ctx context.Context, extra map[string]int
 		srcFrame = cc.cfg.SrcFrame
 	}
 
-	pc, err = cc.client.TransformPointCloud(ctx, pc, srcFrame, "world")
-	if err != nil {
-		return nil, err
+	if !cc.cfg.CropInLocalFrame {
+		pc, err = cc.client.TransformPointCloud(ctx, pc, srcFrame, "world")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	timeB := time.Since(start)
@@ -221,7 +230,7 @@ func (cc *cropCamera) Properties(ctx context.Context) (camera.Properties, error)
 	props := camera.Properties{
 		SupportsPCD: true,
 	}
-	if !cc.cfg.TransformBackToSourceFrame {
+	if !cc.cfg.TransformBackToSourceFrame && !cc.cfg.CropInLocalFrame {
 		return props, nil
 	}
 	srcProps, err := cc.src.Properties(ctx)


### PR DESCRIPTION
## Summary

Adds an opt-in `crop_in_local_frame` mode to the `pc-crop-camera`. By default the camera transforms each point cloud into the `world` frame before applying the `min`/`max` crop box; with this flag the box is applied directly in the source camera's local frame and the world round-trip is skipped. This supports orientation-independent filtering — e.g. dropping points beyond a distance in the camera's local Z — without depending on the robot's frame system for the crop.

## Changes

- **touch/pc_crop_camera.go**: New `crop_in_local_frame` config field. `Validate` rejects combining it with `transform_back_to_source_frame` (in local mode the output is already in the source frame, so transform-back is meaningless). `doNextPointCloud` gates the `TransformPointCloud(src→world)` call on the flag; cropping itself is unchanged and frame-agnostic. `Properties` now forwards the source camera's intrinsics/distortion whenever the output cloud stays in the source frame (either `transform_back_to_source_frame` **or** `crop_in_local_frame`).
- **README.md**: Document the new option and clarify that `min`/`max` are interpreted in the world frame by default, or the local frame when the flag is set.
- **docs/superpowers/**: Design spec and implementation plan for the change.

## Design notes / trade-offs

- The machine connection (`ConnectToMachineFromEnv`) stays unconditional in the constructor even though it's unused in local mode — chosen to avoid nil-guard churn at the cost of an unused connection in local-only setups.
- A single bool was chosen over a general `crop_frame: "world" | "source"` selector (YAGNI); a selector can be added later if more frames are ever needed.

## Testing

- `go build ./...` and `go test ./touch/` pass.
- `go vet ./touch/` produces no new findings versus the base branch (pre-existing unkeyed-struct-literal warnings only).
- Unit tests were intentionally left out of scope for this change.
- Manual verification to do on hardware: configure a `pc-crop-camera` with `crop_in_local_frame: true` and confirm points beyond the local-Z bound are dropped regardless of camera orientation in the world.

## Claude Code Prompts Used

- "I want to augment the pc crop camera with an option to do the croping in the local frame instead of always converting to world. Plan this change"
- "Dont add the unit test, but otherwise looks correct."
- "Create a worktree." / "The spec looks good." / "inline"
- "Push and open a draft PR."

🤖 Generated with [Claude Code](https://claude.com/claude-code)