### PR TITLE
add async FileSaver for motion plan requests

### DIFF
--- a/file_utils/plansaver/saver.go
+++ b/file_utils/plansaver/saver.go
@@ -1,0 +1,187 @@
+package plansaver
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/erh/vmodutils/file_utils"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/rdk/motionplan/armplanning"
+	"golang.org/x/sync/errgroup"
+)
+
+// NewPlanRequestForSaving returns a shallow copy of req suitable for
+// serialization, excluding the WorldState (which motion planning may
+// mutate in place).
+func NewPlanRequestForSaving(req *armplanning.PlanRequest) *armplanning.PlanRequest {
+	return &armplanning.PlanRequest{
+		FrameSystem:    req.FrameSystem,
+		Goals:          req.Goals,
+		StartState:     req.StartState,
+		Constraints:    req.Constraints,
+		PlannerOptions: req.PlannerOptions,
+	}
+}
+
+type SaveFile struct {
+	PassID           string                   `json:"pass_id"`
+	Filename         string                   `json:"filename"`
+	Timestamp        string                   `json:"timestamp"`
+	Req              *armplanning.PlanRequest `json:"-"`
+	PlanningDuration time.Duration            `json:"planning_duration"`
+}
+
+func (sf SaveFile) Filepath() string {
+	return filepath.Join(
+		file_utils.GetPathInCaptureDir(fmt.Sprintf("tag=%s", sf.PassID)),
+		fmt.Sprintf("%s_%s", sf.Timestamp, sf.Filename),
+	)
+}
+
+func NewPlanRequestSaveFile(
+	req *armplanning.PlanRequest,
+	passID string,
+	filename string,
+	now time.Time,
+	planningDuration time.Duration,
+) SaveFile {
+	return SaveFile{
+		PassID:           passID,
+		Filename:         filename,
+		Timestamp:        now.Format("January_02_2006_15_04_05"),
+		Req:              req,
+		PlanningDuration: planningDuration,
+	}
+}
+
+// FileSaver saves files async. If nil, all methods are no-ops.
+type FileSaver struct {
+	ch         chan SaveFile
+	bufferSize int
+	ctx        context.Context
+	cancel     context.CancelFunc
+	g          *errgroup.Group
+	logger     logging.Logger
+}
+
+// NewFileSaver constructs a FileSaver and starts its worker goroutines.
+// Callers must Close (or Drain) when done to avoid leaking workers.
+func NewFileSaver(logger logging.Logger) *FileSaver {
+	const bufferSize = 5000
+	const numWorkers = 8
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &FileSaver{
+		logger:     logger,
+		ch:         make(chan SaveFile, bufferSize),
+		bufferSize: bufferSize,
+		ctx:        ctx,
+		cancel:     cancel,
+		g:          new(errgroup.Group),
+	}
+	for i := range numWorkers {
+		s.g.Go(func() error {
+			s.logger.Infof("FileSaver worker started: %d", i)
+			for {
+				select {
+				case saveFile, ok := <-s.ch:
+					if !ok {
+						s.logger.Infof("FileSaver is drained: %d", i)
+						return nil
+					}
+					s.logger.Debugf("starting writing %s", saveFile.Filepath())
+					if err := file_utils.EnsureDir(filepath.Dir(saveFile.Filepath())); err != nil {
+						return err
+					}
+					if err := saveFile.Req.WriteToFile(saveFile.Filepath()); err != nil {
+						s.logger.Warnw("Error saving motion plan",
+							"filename", saveFile.Filename, "to", saveFile.Filepath(), "err", err)
+					}
+					s.logger.Infof("FileSaver wrote %s (planning %s, %d files remaining in queue)",
+						saveFile.Filepath(), saveFile.PlanningDuration, len(s.ch))
+				case <-s.ctx.Done():
+					s.logger.Infof("FileSaver cancelled: %d", i)
+					return nil
+				}
+			}
+		})
+	}
+	return s
+}
+
+// SaveAsync enqueues sf for background writing. Drops the write if either
+// the caller's ctx or the saver's own ctx is cancelled.
+func (s *FileSaver) SaveAsync(ctx context.Context, sf SaveFile) {
+	if s == nil {
+		return
+	}
+	if sf.PassID == "" {
+		return
+	}
+
+	if ctx.Err() != nil {
+		s.logger.Debugf("FileSaver skipping %s: caller ctx cancelled", sf.Filename)
+		return
+	}
+
+	if s.ctx.Err() != nil {
+		s.logger.Warnf("FileSaver skipping %s: saver already cancelled", sf.Filename)
+		return
+	}
+
+	if len(s.ch) > int(0.8*float64(s.bufferSize)) {
+		s.logger.Warnf("FileSaver channel nearly full: %d/%d", len(s.ch), s.bufferSize)
+	}
+
+	select {
+	case s.ch <- sf:
+	case <-ctx.Done():
+		s.logger.Debugf("FileSaver dropped %s: caller ctx cancelled while enqueuing", sf.Filename)
+	case <-s.ctx.Done():
+		s.logger.Debugf("FileSaver dropped %s: saver cancelled while enqueuing", sf.Filename)
+	}
+}
+
+// Drain closes the channel and waits for all in-flight writes to complete.
+// Only safe when no more SaveAsync calls will happen.
+func (s *FileSaver) Drain() error {
+	if s == nil {
+		return nil
+	}
+	s.logger.Infof("FileSaver draining %d files", len(s.ch))
+	close(s.ch)
+	return s.g.Wait()
+}
+
+// Close stops the workers, giving them up to 5 seconds to finish draining
+// the queue before cancelling in-flight writes.
+func (s *FileSaver) Close() error {
+	if s == nil {
+		return nil
+	}
+	if remaining := len(s.ch); remaining > 0 {
+		s.logger.Warnf("FileSaver closing with %d files remaining — waiting up to 5s for queue to drain", remaining)
+		timer := time.NewTimer(5 * time.Second)
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer timer.Stop()
+		defer ticker.Stop()
+	outer:
+		for {
+			select {
+			case <-timer.C:
+				s.logger.Warnf("FileSaver grace period expired with %d files remaining — these will be dropped", len(s.ch))
+				break outer
+			case <-ticker.C:
+				if len(s.ch) == 0 {
+					s.logger.Infof("FileSaver queue drained within grace period")
+					break outer
+				}
+			}
+		}
+	} else {
+		s.logger.Infof("FileSaver closing with empty queue")
+	}
+	s.cancel()
+	return s.g.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	go.viam.com/rdk v0.129.0
 	go.viam.com/test v1.2.4
 	go.viam.com/utils v0.6.1
+	golang.org/x/sync v0.19.0
 	neilpa.me/go-stl v0.5.0
 )
 
@@ -76,6 +77,8 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-nlopt/nlopt v0.0.0-20230219125344-443d3362dcb5 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -113,6 +116,7 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/lmittmann/ppm v1.0.2 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/dns v1.1.53 // indirect
@@ -147,12 +151,16 @@ require (
 	github.com/pion/webrtc/v4 v4.1.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/samber/lo v1.51.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
+	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/srikrsna/protoc-gen-gotag v0.6.2 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/tklauser/go-sysconf v0.3.12 // indirect
+	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/viamrobotics/ice/v2 v2.3.40 // indirect
 	github.com/viamrobotics/webrtc/v3 v3.99.16 // indirect
@@ -164,6 +172,7 @@ require (
 	github.com/xfmoulet/qoi v0.2.0 // indirect
 	github.com/xtgo/set v1.0.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zhuyie/golzf v0.0.0-20161112031142-8387b0307ade // indirect
 	github.com/zitadel/oidc/v3 v3.37.0 // indirect
 	github.com/zitadel/schema v1.3.1 // indirect
@@ -191,7 +200,6 @@ require (
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -797,6 +798,8 @@ github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/viam-labs/motion-tools v1.9.0 h1:oUcxVMdrwVS7PXkWVYsUJOXkh0aTydmFlK/rciFcGxw=
+github.com/viam-labs/motion-tools v1.9.0/go.mod h1:unpRaVV4ETuJVoHa/3pzknoTnxqjSpfUMewE1vU27BA=
 github.com/viamrobotics/evdev v0.1.3 h1:mR4HFafvbc5Wx4Vp1AUJp6/aITfVx9AKyXWx+rWjpfc=
 github.com/viamrobotics/evdev v0.1.3/go.mod h1:N6nuZmPz7HEIpM7esNWwLxbYzqWqLSZkfI/1Sccckqk=
 github.com/viamrobotics/ice/v2 v2.3.40 h1:H9r4ztsKkxWSn42R4fLvYlaPtpBys1Yj7/MERBtZY0k=
@@ -1047,6 +1050,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1067,6 +1071,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Ports the async FileSaver + NewPlanRequestForSaving from sanding into new subpackage 

Same pattern lives in 4+ modules and copies are already drifting where sanding makes a fix the others don't receive

Kept in its own subpackage so non-motion vmodutils consumers don't inherit `armplanning` as a transitive dep.
  
Kept `PassID` field name to match existing callers - happy to rename to `Tag`/`RunID` if you'd prefer some generic naming.

**Happy to skip if you'd rather keep motion planning concerns out of vmodutils - flag it and I'll close no problem**